### PR TITLE
Change diagnostic message

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ func helper() {
 go vet -vettool=$(which ttempdir) ./...
 
 # a
-./main_test.go:11:14: os.TempDir() can be replaced by `t.TempDir()` in TestMain
-./main_test.go:12:2: os.MkdirTemp() can be replaced by `t.TempDir()` in TestMain
-./main_test.go:20:14: os.TempDir() can be replaced by `t.TempDir()` in TestMain2
+./main_test.go:11:14: os.TempDir() should be replaced by `t.TempDir()` in TestMain
+./main_test.go:12:2: os.MkdirTemp() should be replaced by `t.TempDir()` in TestMain
+./main_test.go:20:14: os.TempDir() should be replaced by `t.TempDir()` in TestMain2
 ```
 
 ### option
@@ -106,10 +106,10 @@ func helper() {
 go vet -vettool=(which ttempdir) -ttempdir.all ./...
 
 # a
-./main_test.go:11:14: os.TempDir() can be replaced by `t.TempDir()` in TestMain
-./main_test.go:12:2: os.MkdirTemp() can be replaced by `t.TempDir()` in TestMain
-./main_test.go:20:14: os.TempDir() can be replaced by `t.TempDir()` in TestMain2
-./main_test.go:24:2: ioutil.TempDir() can be replaced by `testing.TempDir()` in helper
+./main_test.go:11:14: os.TempDir() should be replaced by `t.TempDir()` in TestMain
+./main_test.go:12:2: os.MkdirTemp() should be replaced by `t.TempDir()` in TestMain
+./main_test.go:20:14: os.TempDir() should be replaced by `t.TempDir()` in TestMain2
+./main_test.go:24:2: ioutil.TempDir() should be replaced by `testing.TempDir()` in helper
 ```
 
 ## CI

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -209,7 +209,7 @@ func checkTargetNames(pass *analysis.Pass,
 		if argName == "" {
 			argName = "testing"
 		}
-		pass.Reportf(stmt.Pos(), "%s() can be replaced by `%s.TempDir()` in %s", targetName, argName, funcName)
+		pass.Reportf(stmt.Pos(), "%s() should be replaced by `%s.TempDir()` in %s", targetName, argName, funcName)
 
 		return
 	}

--- a/analyzer/testdata/src/a/a.go
+++ b/analyzer/testdata/src/a/a.go
@@ -20,38 +20,38 @@ func setup() {
 
 func F(t *testing.T) {
 	setup()
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 		_ = err
 	}
 }
 
 func BF(b *testing.B) {
 	TBF(b)
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 		_ = err
 	}
 }
 
 func TBF(tb testing.TB) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 		_ = err
 	}
 }
 
 func FF(f *testing.F) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 		_ = err
 	}
 }

--- a/analyzer/testdata/src/a/a_test.go
+++ b/analyzer/testdata/src/a/a_test.go
@@ -11,8 +11,8 @@ var (
 )
 
 func testsetup() {
-	os.MkdirTemp("a", "b")           // if -all = true, want  "os\\.MkdirTemp\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
-	_, err := os.MkdirTemp("a", "b") // if -all = true, want  "os\\.MkdirTemp\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	os.MkdirTemp("a", "b")           // if -all = true, want  "os\\.MkdirTemp\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	_, err := os.MkdirTemp("a", "b") // if -all = true, want  "os\\.MkdirTemp\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
 	if err != nil {
 		_ = err
 	}
@@ -21,38 +21,38 @@ func testsetup() {
 
 func TestF(t *testing.T) {
 	testsetup()
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 		_ = err
 	}
 }
 
 func BenchmarkF(b *testing.B) {
 	TB(b)
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 		_ = err
 	}
 }
 
 func TB(tb testing.TB) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 		_ = err
 	}
 }
 
 func FuzzF(f *testing.F) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 		_ = err
 	}
 }
@@ -60,10 +60,10 @@ func FuzzF(f *testing.F) {
 func TestFunctionLiteral(t *testing.T) {
 	testsetup()
 	t.Run("test", func(t *testing.T) {
-		os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-		_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 		_ = err
-		if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 			_ = err
 		}
 	})
@@ -84,10 +84,10 @@ func TestTDD(t *testing.T) {
 		{"test"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-			_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+			os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+			_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 			_ = err
-			if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+			if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 				_ = err
 			}
 		})
@@ -96,10 +96,10 @@ func TestTDD(t *testing.T) {
 
 func TestLoop(t *testing.T) {
 	for i := 0; i < 3; i++ {
-		os.MkdirTemp(fmt.Sprintf("a%d", i), "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestLoop"
-		_, err := os.MkdirTemp(fmt.Sprintf("a%d", i), "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestLoop"
+		os.MkdirTemp(fmt.Sprintf("a%d", i), "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestLoop"
+		_, err := os.MkdirTemp(fmt.Sprintf("a%d", i), "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestLoop"
 		_ = err
-		if _, err := os.MkdirTemp(fmt.Sprintf("a%d", i), "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestLoop"
+		if _, err := os.MkdirTemp(fmt.Sprintf("a%d", i), "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestLoop"
 			_ = err
 		}
 	}

--- a/analyzer/testdata/src/b/b.go
+++ b/analyzer/testdata/src/b/b.go
@@ -20,38 +20,38 @@ func setup() {
 
 func F(t *testing.T) {
 	setup()
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 		_ = err
 	}
 }
 
 func BF(b *testing.B) {
 	TBF(b)
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 		_ = err
 	}
 }
 
 func TBF(tb testing.TB) {
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 		_ = err
 	}
 }
 
 func FF(f *testing.F) {
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 		_ = err
 	}
 }

--- a/analyzer/testdata/src/b/b_test.go
+++ b/analyzer/testdata/src/b/b_test.go
@@ -10,8 +10,8 @@ var (
 )
 
 func testsetup() {
-	ioutil.TempDir("a", "b")           // if -all = true, want  "ioutil\\.TempDir\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
-	_, err := ioutil.TempDir("a", "b") // if -all = true, want  "ioutil\\.TempDir\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	ioutil.TempDir("a", "b")           // if -all = true, want  "ioutil\\.TempDir\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	_, err := ioutil.TempDir("a", "b") // if -all = true, want  "ioutil\\.TempDir\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
 	if err != nil {
 		_ = err
 	}
@@ -20,38 +20,38 @@ func testsetup() {
 
 func TestF(t *testing.T) {
 	testsetup()
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 		_ = err
 	}
 }
 
 func BenchmarkF(b *testing.B) {
 	TB(b)
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 		_ = err
 	}
 }
 
 func TB(tb testing.TB) {
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 		_ = err
 	}
 }
 
 func FuzzF(f *testing.F) {
-	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
-	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 	_ = err
-	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 		_ = err
 	}
 }
@@ -59,10 +59,10 @@ func FuzzF(f *testing.F) {
 func TestFunctionLiteral(t *testing.T) {
 	testsetup()
 	t.Run("test", func(t *testing.T) {
-		ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-		_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		ioutil.TempDir("a", "b")           // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		_, err := ioutil.TempDir("a", "b") // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 		_ = err
-		if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		if _, err := ioutil.TempDir("a", "b"); err != nil { // want "ioutil\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 			_ = err
 		}
 	})

--- a/analyzer/testdata/src/c/c.go
+++ b/analyzer/testdata/src/c/c.go
@@ -18,35 +18,35 @@ func setup() {
 
 func F(t *testing.T) {
 	setup()
-	os.TempDir()                        // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	t.Log(os.TempDir())                 // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	os.TempDir()                        // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	t.Log(os.TempDir())                 // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 		_ = dir
 	}
 }
 
 func BF(b *testing.B) {
 	TBF(b)
-	os.TempDir()                        // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
-	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
-	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	os.TempDir()                        // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
+	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
+	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 		_ = dir
 	}
 }
 
 func TBF(tb testing.TB) {
-	os.TempDir()                        // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
-	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
-	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	os.TempDir()                        // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 		_ = dir
 	}
 }
 
 func FF(f *testing.F) {
-	os.TempDir()                        // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
-	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
-	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	os.TempDir()                        // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
+	_ = os.TempDir()                    // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
+	if dir := os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 		_ = dir
 	}
 }

--- a/analyzer/testdata/src/c/c_test.go
+++ b/analyzer/testdata/src/c/c_test.go
@@ -12,42 +12,42 @@ var (
 )
 
 func testsetup() {
-	os.TempDir()        // if -all = true, want  "os\\.TempDir\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
-	dir := os.TempDir() // if -all = true, want  "os\\.TempDir\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	os.TempDir()        // if -all = true, want  "os\\.TempDir\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	dir := os.TempDir() // if -all = true, want  "os\\.TempDir\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
 	_ = dir
 	_ = os.TempDir() // if -all = true, "func setup is not using testing.TempDir"
 }
 
 func TestF(t *testing.T) {
 	testsetup()
-	os.TempDir()                       // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
-	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
-	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	os.TempDir()                       // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
+	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
+	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 		_ = dir
 	}
 }
 
 func BenchmarkF(b *testing.B) {
 	TB(b)
-	os.TempDir()                       // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
-	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
-	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	os.TempDir()                       // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 		_ = dir
 	}
 }
 
 func TB(tb testing.TB) {
-	os.TempDir()                       // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
-	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
-	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	os.TempDir()                       // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
+	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
+	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 		_ = dir
 	}
 }
 
 func FuzzF(f *testing.F) {
-	os.TempDir()                       // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
-	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
-	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	os.TempDir()                       // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	_ = os.TempDir()                   // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 		_ = dir
 	}
 }
@@ -55,9 +55,9 @@ func FuzzF(f *testing.F) {
 func TestFunctionLiteral(t *testing.T) {
 	testsetup()
 	t.Run("test", func(t *testing.T) {
-		os.TempDir()                       // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-		_ = os.TempDir()                   // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-		if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		os.TempDir()                       // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		_ = os.TempDir()                   // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		if dir = os.TempDir(); dir != "" { // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 			_ = dir
 		}
 	})
@@ -73,17 +73,17 @@ func TestEmptyTB(t *testing.T) {
 
 func TestRecursive(t *testing.T) {
 	t.Log( // recursion level 1
-		os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+		os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 	)
 	t.Log( // recursion level 1
 		fmt.Sprintf("%s", // recursion level 2
-			os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+			os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 		),
 	)
 	t.Log( // recursion level 1
 		filepath.Clean( // recursion level 2
 			fmt.Sprintf("%s", // recursion level 3
-				os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+				os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 			),
 		),
 	)
@@ -91,7 +91,7 @@ func TestRecursive(t *testing.T) {
 		filepath.Join( // recursion level 2
 			filepath.Clean( // recursion level 3
 				fmt.Sprintf("%s", // recursion level 4
-					os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+					os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 				),
 			),
 			"test",

--- a/analyzer/testdata/src/d/d.go
+++ b/analyzer/testdata/src/d/d.go
@@ -20,38 +20,38 @@ func setup() {
 
 func F(t *testing.T) {
 	setup()
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in F"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in F"
 		_ = err
 	}
 }
 
 func BF(b *testing.B) {
 	TBF(b)
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BF"
 		_ = err
 	}
 }
 
 func TBF(tb testing.TB) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TBF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TBF"
 		_ = err
 	}
 }
 
 func FF(f *testing.F) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FF"
 		_ = err
 	}
 }

--- a/analyzer/testdata/src/d/d_test.go
+++ b/analyzer/testdata/src/d/d_test.go
@@ -10,48 +10,48 @@ var (
 )
 
 func testsetup() {
-	os.MkdirTemp("a", "b")           // want  "os\\.MkdirTemp\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
-	_, err := os.MkdirTemp("a", "b") // want  "os\\.MkdirTemp\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	os.MkdirTemp("a", "b")           // want  "os\\.MkdirTemp\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	_, err := os.MkdirTemp("a", "b") // want  "os\\.MkdirTemp\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
 	if err != nil {
 		_ = err
 	}
-	os.MkdirTemp("a", "b") // want  "os\\.MkdirTemp\\(\\) can be replaced by `testing\\.TempDir\\(\\)` in testsetup"
+	os.MkdirTemp("a", "b") // want  "os\\.MkdirTemp\\(\\) should be replaced by `testing\\.TempDir\\(\\)` in testsetup"
 }
 
 func TestF(t *testing.T) {
 	testsetup()
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestF"
 		_ = err
 	}
 }
 
 func BenchmarkF(b *testing.B) {
 	TB(b)
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `b\\.TempDir\\(\\)` in BenchmarkF"
 		_ = err
 	}
 }
 
 func TB(tb testing.TB) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `tb\\.TempDir\\(\\)` in TB"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `tb\\.TempDir\\(\\)` in TB"
 		_ = err
 	}
 }
 
 func FuzzF(f *testing.F) {
-	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
-	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 	_ = err
-	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `f\\.TempDir\\(\\)` in FuzzF"
+	if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `f\\.TempDir\\(\\)` in FuzzF"
 		_ = err
 	}
 }
@@ -59,10 +59,10 @@ func FuzzF(f *testing.F) {
 func TestFunctionLiteral(t *testing.T) {
 	testsetup()
 	t.Run("test", func(t *testing.T) {
-		os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
-		_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		os.MkdirTemp("a", "b")           // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		_, err := os.MkdirTemp("a", "b") // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 		_ = err
-		if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) can be replaced by `t\\.TempDir\\(\\)` in anonymous function"
+		if _, err := os.MkdirTemp("a", "b"); err != nil { // want "os\\.MkdirTemp\\(\\) should be replaced by `t\\.TempDir\\(\\)` in anonymous function"
 			_ = err
 		}
 	})

--- a/analyzer/testdata/src/e/e_test.go
+++ b/analyzer/testdata/src/e/e_test.go
@@ -9,17 +9,17 @@ import (
 
 func TestRecursive(t *testing.T) {
 	t.Log( // recursion level 1
-		os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+		os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 	)
 	t.Log( // recursion level 1
 		fmt.Sprintf("%s", // recursion level 2
-			os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+			os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 		),
 	)
 	t.Log( // recursion level 1
 		filepath.Clean( // recursion level 2
 			fmt.Sprintf("%s", // recursion level 3
-				os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+				os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 			),
 		),
 	)
@@ -27,7 +27,7 @@ func TestRecursive(t *testing.T) {
 		filepath.Join( // recursion level 2
 			filepath.Clean( // recursion level 3
 				fmt.Sprintf("%s", // recursion level 4
-					os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+					os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 				),
 			),
 			"test",
@@ -38,7 +38,7 @@ func TestRecursive(t *testing.T) {
 			filepath.Join( // recursion level 3
 				filepath.Clean( // recursion level 4
 					fmt.Sprintf("%s", // recursion level 5
-						os.TempDir(), // want "os\\.TempDir\\(\\) can be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
+						os.TempDir(), // want "os\\.TempDir\\(\\) should be replaced by `t\\.TempDir\\(\\)` in TestRecursive"
 					),
 				),
 				"test",


### PR DESCRIPTION
Based on this suggestion from @Antonboom 

https://github.com/golangci/golangci-lint/pull/4794#issuecomment-2149000616

instead:

> ./main_test.go:11:14: os.TempDir() can be replaced by t.TempDir() in TestMain

we will:

> ./main_test.go:11:14: os.TempDir() should be replaced by t.TempDir() in TestMain