### PR TITLE
update analyzer doc with proper Go version

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name = "ttempdir"
-	doc  = name + " is analyzer that detects using os.MkdirTemp, ioutil.TempDir or os.TempDir instead of t.TempDir since Go1.17" //nolint: lll
+	doc  = name + " is analyzer that detects using os.MkdirTemp, ioutil.TempDir or os.TempDir instead of t.TempDir since Go1.15" //nolint:lll
 	url  = "https://github.com/peczenyj/ttempdir"
 
 	defaultAll               = false


### PR DESCRIPTION
According to [the doc](https://pkg.go.dev/testing#T.TempDir), `t.TempDir` appeared in stdlib since Go 1.15:

<img width="1140" alt="image" src="https://github.com/peczenyj/ttempdir/assets/3228886/9d117bb4-5b5d-4beb-a888-4319bd749cc0">
